### PR TITLE
Jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,8 +130,7 @@ dependencies {
     implementation fg.deobf("curse.maven:patchouli-306770:4636277")
 
     implementation fg.deobf("curse.maven:terrafirmacraft-302973:5571484")
-    implementation fg.deobf("curse.maven:firmalife-453394:5775257")
-
+    implementation fg.deobf("curse.maven:firmalife-453394:6249092")
 
     implementation fg.deobf("curse.maven:mouse-tweaks-60089:4581240")
 

--- a/src/main/resources/data/firmalife/recipes/anvil/stainless_steel_jar_lid.json
+++ b/src/main/resources/data/firmalife/recipes/anvil/stainless_steel_jar_lid.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:false"
+    }
+  ],
+  "type": "tfc:anvil",
+  "input": {
+    "tag": "forge:ingots/stainless_steel"
+  },
+  "result": {
+    "item": "firmalife:stainless_steel_jar_lid",
+    "count": 16
+  },
+  "tier": 4,
+  "rules": [
+    "hit_last",
+    "hit_second_last",
+    "punch_third_last"
+  ]
+}

--- a/src/main/resources/data/lithicaddon/recipes/crafting/stainless_steel_lid_exchange.json
+++ b/src/main/resources/data/lithicaddon/recipes/crafting/stainless_steel_lid_exchange.json
@@ -1,0 +1,17 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "firmalife"
+    }
+  ],
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "firmalife:stainless_steel_jar_lid"
+    }
+  ],
+  "result": {
+    "item": "lithicaddon:stainless_steel_lid"
+  }
+}

--- a/src/main/resources/data/tfc/tags/items/jars.json
+++ b/src/main/resources/data/tfc/tags/items/jars.json
@@ -46,8 +46,6 @@
     "lithicaddon:stainless_steel_jar/strawberry",
     "lithicaddon:aluminum_jar/wintergreen_berry",
     "lithicaddon:stainless_steel_jar/wintergreen_berry",
-    "lithicaddon:empty_jar_with_stainless_steel_lid",
-    "lithicaddon:empty_jar_with_aluminum_lid",
     "lithicaddon:aluminum_jar/fig",
     "lithicaddon:stainless_steel_jar/fig",
     "lithicaddon:aluminum_jar/pineapple",


### PR DESCRIPTION
- Updated the version of Firmalife
- Removed Firmalife stainless steel jar lid recipe
- Added a recipe to turn Firmalife SS jar lids into their Lithic Addon counterparts
- Removed empty jars with lids from the `tfc:jars` tag as it caused the wrong item size to be assigned. This is in line with how Firmalife does it