### PR TITLE
Fixed basket mechanics and improved related config

### DIFF
--- a/src/main/java/com/redstoneguy10ls/lithicaddon/common/items/FruitBEEsket.java
+++ b/src/main/java/com/redstoneguy10ls/lithicaddon/common/items/FruitBEEsket.java
@@ -1,42 +1,13 @@
 package com.redstoneguy10ls.lithicaddon.common.items;
 
-import com.eerussianguy.firmalife.common.capabilities.bee.BeeCapability;
-import com.redstoneguy10ls.lithicaddon.common.capabilities.moth.MothCapability;
-import com.redstoneguy10ls.lithicaddon.config.LithicConfig;
-import com.redstoneguy10ls.lithicaddon.util.FruitPicker;
-import com.redstoneguy10ls.lithicaddon.util.LithicHelpers;
-import net.dries007.tfc.common.TFCTags;
-import net.dries007.tfc.common.blocks.plant.fruit.Lifecycle;
-import net.dries007.tfc.common.capabilities.Capabilities;
-import net.dries007.tfc.common.items.TFCItems;
-import net.dries007.tfc.util.Helpers;
-import net.minecraft.core.BlockPos;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.ClickAction;
-import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.PipeBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.fluids.capability.IFluidHandler;
-import net.minecraftforge.items.ItemHandlerHelper;
-import org.jetbrains.annotations.NotNull;
-
-import static net.dries007.tfc.common.blocks.plant.fruit.FruitTreeLeavesBlock.LIFECYCLE;
-import static net.dries007.tfc.common.blocks.plant.fruit.Lifecycle.FRUITING;
-
 public class FruitBEEsket extends FruitBasket {
     public FruitBEEsket(Properties pProperties) {
         super(pProperties);
     }
 
     @Override
-    public boolean beesket()
+    public boolean isRegularBasket()
     {
-      return true;
+      return false;
     }
 }

--- a/src/main/java/com/redstoneguy10ls/lithicaddon/common/items/FruitBasket.java
+++ b/src/main/java/com/redstoneguy10ls/lithicaddon/common/items/FruitBasket.java
@@ -41,7 +41,7 @@ public class FruitBasket extends Item {
     @Override
     public boolean overrideOtherStackedOnMe(ItemStack stack, ItemStack other, Slot slot, ClickAction action, Player player, SlotAccess carried)
     {
-        if(action == ClickAction.SECONDARY && beesket() && stack.getDamageValue() == 0)
+        if(action == ClickAction.SECONDARY && isRegularBasket() && stack.getDamageValue() == 0)
         {
             return other.getCapability(BeeCapability.CAPABILITY).map(bee->{
                 if(bee.hasQueen())
@@ -107,11 +107,13 @@ public class FruitBasket extends Item {
                             }
                         }
                     }
-                    final int test = level.random.nextInt(1, 100);
-                    System.out.println(test);
-                    if (test <= Helpers.getValueOrDefault(LithicConfig.SERVER.fruitTreeBreakChance) && fruitingLeaves > 0 && beesket())
+                    
+                    if (isRegularBasket() && fruitingLeaves > 0)
                     {
-                        level.destroyBlock(pos, true);
+                        if (level.random.nextDouble() <= Helpers.getValueOrDefault(LithicConfig.SERVER.fruitTreeBranchBreakChance))
+                        {
+                            level.destroyBlock(pos, true);
+                        }
                     }
                     held.hurtAndBreak(fruitingLeaves, player, p -> {});
                     while (fruitingLeaves > 0)
@@ -130,7 +132,7 @@ public class FruitBasket extends Item {
     }
 
 
-    public boolean beesket()
+    public boolean isRegularBasket()
     {
       return true;
     }

--- a/src/main/java/com/redstoneguy10ls/lithicaddon/common/items/FruitBasket.java
+++ b/src/main/java/com/redstoneguy10ls/lithicaddon/common/items/FruitBasket.java
@@ -31,10 +31,8 @@ import static net.dries007.tfc.common.blocks.plant.fruit.Lifecycle.FRUITING;
 
 public class FruitBasket extends Item {
 
-    private boolean gay;
     public FruitBasket(Properties pProperties) {
         super(pProperties);
-        gay = false;
     }
 
 
@@ -68,13 +66,6 @@ public class FruitBasket extends Item {
 
     @Override
     public @NotNull InteractionResult useOn(UseOnContext context) {
-
-        gay = !gay;
-        if(gay)
-        {
-            return InteractionResult.PASS;
-        }
-
 
         final Level level = context.getLevel();
         final BlockPos pos = context.getClickedPos();

--- a/src/main/java/com/redstoneguy10ls/lithicaddon/config/LithicServerConfig.java
+++ b/src/main/java/com/redstoneguy10ls/lithicaddon/config/LithicServerConfig.java
@@ -28,7 +28,7 @@ public class LithicServerConfig {
 
     public final BooleanValue betterHorseBreeding;
 
-    public final IntValue fruitTreeBreakChance;
+    public final DoubleValue fruitTreeBranchBreakChance;
 
 
 
@@ -70,16 +70,16 @@ public class LithicServerConfig {
                 .defineInRange("maxrain",400.0f, 0.0f, 500.0f);
 
         mothEatChance = builder.apply("mothEatChance")
-                .comment("The chance out of 100 the fruit leaves will be consumed each day. set to 100 to gaurentee they eat ")
+                .comment("The chance out of 100 the fruit leaves will be consumed each day. Set to 100 to guarantee they eat ")
                 .defineInRange("mothEatChance",50, 0, 100);
 
         betterHorseBreeding = builder.apply("betterHorseBreeding")
                         .comment("Whether or not make horse offsprings get a bonus to speed based on the parents familiarity")
                         .define("betterHorseBreeding", true);
 
-        fruitTreeBreakChance = builder.apply("fruitTreeBreakChance")
-                .comment("The chance out of 100 that a fruit tree breaks when using a fruit basket. Set to zero to disable")
-                .defineInRange("fruitTreeBreakChance",5, 0, 100);
+        fruitTreeBranchBreakChance = builder.apply("fruitTreeBranchBreakChance")
+                .comment("The chance that a fruit tree branch breaks when using a fruit basket. Set to zero to disable")
+                .defineInRange("fruitTreeBranchBreakChance", 0.05, 0.0, 1.0);
 
 
         innerBuilder.pop();


### PR DESCRIPTION
- Renamed `FruitBasket.beesket()` into `FruitBasket.isRegularBasket()` to make the use more clear, and changed the override in `FruitBEEsket.isRegularBasket()` to return false, so it actually works as intended
- Renamed the config `fruitTreeBreakChance` to `fruitTreeBranchBreakChance` to reflect the effects of the config more accurately, and changed the type of the config to `double` to allow non-integer percentage values
- Removed the class attribute `FruitBasket.gay`, as the sole use for this variable didn't have any effect on gameplay. In case it was intended to act as a cooldown for using the fruit basket, it did not work and should be replaced by a proper item use cooldown